### PR TITLE
Add return of updated cursor in SwapProps

### DIFF
--- a/mixins/swapProps.js
+++ b/mixins/swapProps.js
@@ -1,6 +1,6 @@
 module.exports = {
   swapProps: function (obj) {
-    this.props.cursor.update(function (state) {
+    return this.props.cursor.update(function (state) {
       return state.mergeDeep(obj);
     });
   }


### PR DESCRIPTION
Sometimes I want to get the resulted cursor after `this.swapProps`
